### PR TITLE
feat: add account age check (30+ days) for anti-spam

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -157,6 +157,16 @@ Only users with the following permissions can trigger the bot:
 
 This prevents spam from random users.
 
+### Account Age Requirement
+
+The bot also checks that user accounts are at least **30 days old** before responding. This additional anti-spam measure helps prevent abuse from newly created accounts.
+
+- Users with accounts younger than 30 days will receive a polite rejection message
+- Manual workflow dispatch (via Actions tab) bypasses this check
+- The check is skipped if account creation date cannot be determined
+
+**Note**: This requirement can be customized by modifying the `AGE_DAYS -ge 30` condition in the workflow file.
+
 ## Managing Workflow Notifications
 
 ### Disabling Workflow Notification Emails

--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -91,15 +91,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
-      # Build oh-my-opencode
       - name: Build oh-my-opencode
+        if: steps.account_age.outputs.skip_check == 'true' || steps.account_age.outputs.account_old_enough == 'true'
         working-directory: oh-my-opencode
         run: |
           bun install
           bun run build
 
-      # Install OpenCode + configure local plugin + auth in single step
       - name: Setup OpenCode with oh-my-opencode
+        if: steps.account_age.outputs.skip_check == 'true' || steps.account_age.outputs.account_old_enough == 'true'
         env:
           OPENCODE_AUTH_JSON: ${{ secrets.OPENCODE_AUTH_JSON }}
         run: |
@@ -356,6 +356,49 @@ jobs:
             echo "comment_id=" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check Account Age
+        id: account_age
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          AUTHOR: ${{ steps.context.outputs.author }}
+        run: |
+          if [[ "${{ steps.context.outputs.type }}" == "dispatch" ]]; then
+            echo "skip_check=true" >> $GITHUB_OUTPUT
+            echo "Account age check skipped for manual workflow dispatch"
+            exit 0
+          fi
+          
+          if [[ "$AUTHOR" == "cloudwaddie-agent" ]]; then
+            echo "skip_check=true" >> $GITHUB_OUTPUT
+            echo "Account age check skipped for bot itself"
+            exit 0
+          fi
+          
+          USER_DATA=$(gh api users/$AUTHOR)
+          CREATED_AT=$(echo "$USER_DATA" | jq -r '.created_at')
+          
+          if [[ "$CREATED_AT" == "null" || -z "$CREATED_AT" ]]; then
+            echo "skip_check=true" >> $GITHUB_OUTPUT
+            echo "Could not determine account creation date, allowing"
+            exit 0
+          fi
+          
+          CREATED_SECONDS=$(date -d "$CREATED_AT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$CREATED_AT" +%s 2>/dev/null)
+          NOW_SECONDS=$(date +%s)
+          AGE_DAYS=$(( (NOW_SECONDS - CREATED_SECONDS) / 86400 ))
+          
+          echo "User: $AUTHOR"
+          echo "Account created: $CREATED_AT"
+          echo "Account age: $AGE_DAYS days"
+          
+          if [[ $AGE_DAYS -ge 30 ]]; then
+            echo "account_old_enough=true" >> $GITHUB_OUTPUT
+            echo "Account is $AGE_DAYS days old (>= 30 days) - allowing"
+          else
+            echo "account_old_enough=false" >> $GITHUB_OUTPUT
+            echo "Account is only $AGE_DAYS days old (< 30 days) - rejecting"
+          fi
+
       # Add :eyes: reaction (as cloudwaddie-agent)
       - name: Add eyes reaction
         env:
@@ -393,6 +436,7 @@ jobs:
           fi
 
       - name: Run oh-my-opencode
+        if: steps.account_age.outputs.skip_check == 'true' || steps.account_age.outputs.account_old_enough == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           USER_COMMENT: ${{ steps.context.outputs.comment }}
@@ -404,6 +448,26 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           export PATH="$HOME/.opencode/bin:$PATH"
+
+      - name: Reject request from new account
+        if: steps.account_age.outputs.account_old_enough == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          AUTHOR="${{ steps.context.outputs.author }}"
+          NUMBER="${{ steps.context.outputs.number }}"
+          TYPE="${{ steps.context.outputs.type }}"
+          
+          REJECT_MESSAGE="@$AUTHOR Sorry, I can only respond to users with GitHub accounts older than 30 days. This helps prevent spam and abuse. Please try again once your account is older, or contact the repository maintainers directly."
+          
+          if [[ -n "$NUMBER" ]]; then
+            if [[ "$TYPE" == "pr" ]]; then
+              gh pr comment "$NUMBER" --body "$REJECT_MESSAGE"
+            else
+              gh issue comment "$NUMBER" --body "$REJECT_MESSAGE"
+            fi
+          fi
+          echo "Request rejected: Account too new"
 
           PROMPT=$(cat <<'PROMPT_EOF'
           [analyze-mode]

--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ A GitHub **workflow template** that runs **cloudwaddie-agent** (an autonomous bo
 
 ## Notes
 - The workflow only runs on mentions by a **contributor** (OWNER/MEMBER/COLLABORATOR/CONTRIBUTOR).
+- The workflow checks that user accounts are at least **30 days old** to prevent spam (manual workflow dispatch bypasses this check).
 - Uses **free OpenCode models** by default (opencode/big-pickle)
 - Authentication is optional - works with free models out of the box


### PR DESCRIPTION
## Summary

- Added account age validation to the workflow that checks if user accounts are at least 30 days old before responding
- Added rejection message for users with newer accounts to politely decline their requests
- Added conditional execution for build, setup, and run steps based on account age
- Updated README documentation with the new feature
- Manual workflow dispatch bypasses the account age check

This addresses the request to add testing for issue triaging for accounts over 30 days.

## Changes

- `.github/workflows/cloudwaddie-agent.yml`: Added "Check Account Age" step and conditional execution
- `README.md`: Added note about account age requirement
- `.github/workflows/README.md`: Added "Account Age Requirement" section with documentation