### PR TITLE
fix: fetch issue/PR body via gh api to handle multiline content

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -315,8 +315,10 @@ jobs:
             # Issue opened/edited
             ISSUE_NUM="${{ github.event.issue.number }}"
             AUTHOR="${{ github.event.issue.user.login }}"
-            COMMENT_BODY="${{ github.event.issue.body }}"
             TITLE="${{ github.event.issue.title }}"
+            
+            # Use gh api to fetch body reliably (handles multiline, special chars)
+            COMMENT_BODY=$(gh api "repos/$REPO/issues/${ISSUE_NUM}" --jq '.body // ""')
             
             echo "type=issue" >> $GITHUB_OUTPUT
             echo "number=${ISSUE_NUM}" >> $GITHUB_OUTPUT
@@ -331,8 +333,10 @@ jobs:
             # PR opened/edited
             PR_NUM="${{ github.event.pull_request.number }}"
             AUTHOR="${{ github.event.pull_request.user.login }}"
-            COMMENT_BODY="${{ github.event.pull_request.body }}"
             TITLE="${{ github.event.pull_request.title }}"
+            
+            # Use gh api to fetch body reliably (handles multiline, special chars)
+            COMMENT_BODY=$(gh api "repos/$REPO/pulls/${PR_NUM}" --jq '.body // ""')
             
             echo "type=pr" >> $GITHUB_OUTPUT
             echo "number=${PR_NUM}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

When the bot is mentioned in an issue/PR **body** (not a comment), the agent receives an empty or truncated body. This causes the agent to not understand what was requested.

### Examples:
- ✅ Works: Mention in a **comment** (issue #14)
- ❌ Broken: Mention in **issue body** (issue #23)

In the workflow logs, we saw: `"The issue has no body but asks me to make a PR..."` even though issue #23 clearly has a body.

## Root Cause

GitHub Actions context variables like `${{ github.event.issue.body }}` don't reliably handle multiline strings. The body content gets mangled during bash variable expansion, resulting in:
- Truncated content
- Lost newlines
- Special character issues

## Solution

Instead of relying on GitHub Actions context variables, fetch the issue/PR body directly from the GitHub API using `gh api` with `jq`:

```bash
# Before (unreliable):
COMMENT_BODY="${{ github.event.issue.body }}"

# After (reliable):
COMMENT_BODY=$(gh api "repos/$REPO/issues/${ISSUE_NUM}" --jq '.body // ""')
```

This ensures:
- ✅ Full multiline content preserved
- ✅ Special characters handled correctly  
- ✅ Empty bodies handled gracefully (`// ""`)
- ✅ Consistent behavior for both issue and PR bodies

## Changes

- Updated "Collect Context" step to fetch issue body via `gh api`
- Updated "Collect Context" step to fetch PR body via `gh api`
- Both now use the same reliable extraction method as comments already do

## Testing

After this fix, the agent should correctly receive the full issue/PR body when mentioned in the body itself, not just in comments.