### PR TITLE
fix: remove unset GITHUB_TOKEN lines

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -53,7 +53,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          unset GITHUB_TOKEN  # Ensure gh uses GH_TOKEN (PAT) not GITHUB_TOKEN (Actions token)
           # GH_TOKEN environment variable is automatically used by gh CLI
           # Verify authentication works
           gh auth status || echo "Using GH_TOKEN environment variable for authentication"
@@ -287,7 +286,6 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REPO: ${{ github.repository }}
         run: |
-          unset GITHUB_TOKEN  # Ensure gh uses GH_TOKEN (PAT) not GITHUB_TOKEN (Actions token)
           if [[ "$EVENT_NAME" == "issue_comment" ]]; then
             # Comment on issue or PR
             ISSUE_NUM="${{ github.event.issue.number }}"
@@ -365,7 +363,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          unset GITHUB_TOKEN  # Ensure gh uses GH_TOKEN (PAT) not GITHUB_TOKEN (Actions token)
           if [[ -n "${{ steps.context.outputs.comment_id }}" ]]; then
             # React to comment
             gh api "/repos/${{ github.repository }}/issues/comments/${{ steps.context.outputs.comment_id }}/reactions" \
@@ -387,7 +384,6 @@ jobs:
           REPO_NAME: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          unset GITHUB_TOKEN  # Ensure gh uses GH_TOKEN (PAT) not GITHUB_TOKEN (Actions token)
           export PATH="$HOME/.opencode/bin:$PATH"
 
           PROMPT=$(cat <<'PROMPT_EOF'
@@ -498,7 +494,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          unset GITHUB_TOKEN  # Ensure gh uses GH_TOKEN (PAT) not GITHUB_TOKEN (Actions token)
           if [[ -n "${{ steps.context.outputs.comment_id }}" ]]; then
             REACTION_ID=$(gh api "/repos/${{ github.repository }}/issues/comments/${{ steps.context.outputs.comment_id }}/reactions" \
               --jq '.[] | select(.content == "eyes" and .user.login == "cloudwaddie-agent") | .id' | head -1)


### PR DESCRIPTION
## Problem

The bot was working correctly for issue #14 (Feb 14), but recent changes may have broken it. Specifically, `unset GITHUB_TOKEN` lines were added in commit `14cb946` but weren't present when the bot successfully processed requests.

## Analysis

Looking at the working timeline:
- ✅ **Issue #14 (Feb 14)**: Bot worked perfectly - mentioned in a comment, responded correctly
- ❌ **Issue #23 (Feb 15)**: Bot mentioned in issue body, said "issue has no body"

The `unset GITHUB_TOKEN` commands were added between these working and failing instances.

## Root Cause

The `unset GITHUB_TOKEN` lines were added to force `gh` CLI to use the PAT token (`GH_TOKEN`), but this may be causing issues:

1. GitHub Actions already sets `GITHUB_TOKEN` for the workflow
2. Unsetting it might interfere with other operations or context
3. The `GH_TOKEN` environment variable should be sufficient for `gh` CLI to use the PAT

## Solution

Remove all `unset GITHUB_TOKEN` lines from the workflow. The `GH_TOKEN` environment variable alone is sufficient - `gh` CLI will use it automatically when present.

```bash
# Before (5 instances):
unset GITHUB_TOKEN  # Ensure gh uses GH_TOKEN (PAT) not GITHUB_TOKEN (Actions token)

# After:
# (removed - GH_TOKEN env var is sufficient)
```

## Changes

- Removed 5 instances of `unset GITHUB_TOKEN` from:
  - "Authenticate gh CLI as cloudwaddie-agent" step
  - "Collect Context" step  
  - "Add eyes reaction" step
  - "Run oh-my-opencode" step
  - "Update reaction" step

## Testing

After this fix, the workflow should behave like it did when issue #14 was successfully handled.