### PR TITLE
fix: enable fork-based git workflow for agent

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -100,48 +100,40 @@ Go to your repository's **Settings → Secrets and variables → Actions** and a
 
 ### 2. Workflow Permissions (Security Configuration)
 
-**IMPORTANT**: This workflow uses **read-only permissions** for security.
+**IMPORTANT**: This workflow uses **write permissions** for fork-based git workflow.
 
 **What this means**:
-- The workflow itself has `permissions: contents: read` (read-only access)
-- All write operations (comments, reactions, git operations) are performed via the `GH_PAT` token
-- The PAT token provides the necessary write access through `gh` CLI commands
-- **No contributor/collaborator access required** for the bot account
+- The workflow has `permissions: contents: write` and `pull-requests: write`
+- The bot creates a fork, pushes to the fork, and creates a PR to the main repository
+- This allows the agent to make changes even without contributor access to the main repo
 
-**Security benefits**:
-- Minimizes attack surface by limiting workflow permissions
-- Follows principle of least privilege
-- Write operations are explicit and auditable through PAT token usage
-
-**What the bot CAN do** (via GH_PAT):
+**What the bot CAN do**:
+- Fork the repository
 - Add and remove emoji reactions to issues/PRs/comments
 - Post comments
 - Create pull requests
-- Commit and push changes
+- Commit and push changes to fork
 - Run git operations
 
-**What the bot CANNOT do** (intentionally restricted):
+**What the bot CANNOT do**:
+- Push directly to the main repository (uses fork workflow instead)
 - Manage labels (removed for security - uses emojis instead)
-- Direct workflow write access (uses read-only permissions)
 
 ### 3. Workflow Permissions (No Action Required)
 
-**No action needed** - the workflow is configured with read-only permissions by default.
+**No action needed** - the workflow is configured with write permissions by default.
 
 The workflow file specifies:
 ```yaml
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 ```
 
-This means the workflow itself only has read access. All write operations are performed through the `GH_PAT` token, which provides secure, auditable write access.
-
-**You do NOT need to**:
-- Enable "Read and write permissions" in repository settings
-- Grant the bot account contributor/collaborator access
-- Configure additional permissions
-
-The `GH_PAT` token handles all write operations securely through the `gh` CLI.
+This allows the agent to:
+1. Fork the repo using `gh repo fork`
+2. Push changes to the fork
+3. Create a PR from the fork to the main repo
 
 ### 4. Rename the Bot (Optional)
 
@@ -251,7 +243,7 @@ By default, GitHub sends email notifications for every workflow run, which can b
    - Update `GH_PAT` with the new token
 4. Re-run the workflow
 
-**Note**: The workflow uses **read-only permissions** (`contents: read`) by design. All write operations are performed via the `GH_PAT` token through `gh` CLI, which is more secure than granting workflow-level write permissions.
+**Note**: The workflow uses **write permissions** (`contents: write`, `pull-requests: write`) to enable fork-based git workflow. The bot forks the repo, pushes to the fork, and creates a PR to the main repository.
 
 ### Bot fails with "Invalid token" or "Bad credentials"
 

--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -33,7 +33,8 @@ jobs:
        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association || ''))
 
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
 
     steps:
       # Checkout with cloudwaddie-agent's PAT
@@ -477,13 +478,14 @@ jobs:
           2. **Break down work** into atomic, verifiable steps
           3. **GIT WORKFLOW** (for implementation tasks):
              
-             **YOU HAVE READ-ONLY WORKFLOW PERMISSIONS** - Cannot push directly to this repository.
-             **ALL GIT OPERATIONS MUST USE GH CLI WITH PAT TOKEN**:
-             - When creating commits: Use `git` commands as normal (PAT provides auth)
-             - When pushing: Use `git push` (PAT token provides write access via credentials)
-             - When creating PRs: Use `gh pr create` (authenticates via GH_TOKEN env var)
-             
-             **CRITICAL**: The workflow has `contents: read` permissions for security. All write operations happen through your PAT token (`GH_TOKEN` env var), not the workflow token.
+              **GIT WORKFLOW**: Use fork-based workflow for all changes:
+              1. Fork the repo: `gh repo fork` (creates fork under your account)
+              2. Add fork as remote: `git remote add fork https://github.com/cloudwaddie-agent/REPO.git`
+              3. Push to fork: `git push -u fork BRANCH`
+              4. Create PR: `gh pr create --base main --head YOUR_BRANCH`
+              
+              **IMPORTANT**: Always use fork workflow. Never push directly to the main repository.
+              Use `gh repo fork` to create a fork, then push to the fork and create a PR.
 
           4. **Plan everything BEFORE starting** any work
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ A GitHub **workflow template** that runs **cloudwaddie-agent** (an autonomous bo
 3. Ensure the workflow file is enabled.
 
 ## Security Features
-- **Read-only workflow permissions** (`contents: read` only)
+- **Write workflow permissions** (`contents: write`, `pull-requests: write`) for fork and PR workflow
 - All write operations (comments, reactions, git operations) are performed via the `GH_PAT` token through `gh` CLI
 - **No label management** - uses emoji reactions instead (👀 when working, 👍 when done)
-- The bot itself handles all git operations (commits, pushes, PRs) - no separate workflow push step
+- The bot uses **fork-based workflow**: forks the repo, pushes to fork, creates PR to main
 
 ## Notes
 - The workflow only runs on mentions by a **contributor** (OWNER/MEMBER/COLLABORATOR/CONTRIBUTOR)


### PR DESCRIPTION
## Summary
- Changed workflow permissions from `contents: read` to `contents: write`
- Added `pull-requests: write` permission
- Updated agent prompt to use fork workflow (gh repo fork, push to fork, create PR)
- Updated README documentation to reflect new permissions and workflow

Fixes #37 (Git not working - agent cannot push)
Fixes #35 (related caching issues - previously couldn't create PR)

## Changes

### Workflow Permissions
```yaml
# Before
permissions:
  contents: read

# After
permissions:
  contents: write
  pull-requests: write
```

### Agent Git Workflow
The agent now uses fork-based workflow:
1. Fork the repo: `gh repo fork`
2. Add fork as remote
3. Push to fork: `git push -u fork BRANCH`
4. Create PR: `gh pr create --base main --head YOUR_BRANCH`