### PR TITLE
fix(workflow): disable set -e to properly capture gh api exit codes

### DIFF
--- a/.github/workflows/fork-cleanup.yml
+++ b/.github/workflows/fork-cleanup.yml
@@ -33,16 +33,20 @@ jobs:
             echo "Cleaning up fork branch: $BRANCH_NAME"
             
             # Delete the branch from the fork using gh API
+            # Note: Disable set -e to capture the exit code properly
             echo "Deleting branch via API..."
+            set +e
             RESPONSE=$(gh api "repos/$FORK_REPO/git/refs/heads/$BRANCH_NAME" -X DELETE 2>&1)
             EXIT_CODE=$?
+            set -e
             
             echo "API Response: $RESPONSE"
             echo "Exit code: $EXIT_CODE"
             
             if [ $EXIT_CODE -eq 0 ]; then
               echo "Successfully deleted branch: $BRANCH_NAME"
-            elif echo "$RESPONSE" | grep -q "Not Found"; then
+            elif [ $EXIT_CODE -eq 4 ] || echo "$RESPONSE" | grep -q "Not Found"; then
+              # Exit code 4 from gh api typically means "Not Found" (404)
               echo "Branch already deleted or does not exist (404)"
             else
               echo "Failed to delete branch. Exit code: $EXIT_CODE"


### PR DESCRIPTION
## Summary
- Fix the fork cleanup workflow that was failing with exit code 4
- The issue was that bash runs with `set -e`, which causes the script to exit immediately when `gh api` returns a non-zero exit code
- This prevented the `EXIT_CODE=$?` from ever running, making the error handling useless

## Changes
1. Add `set +e` before the `gh api` call to disable exit-on-error
2. Capture the exit code properly
3. Re-enable `set -e` after the API call
4. Also check for exit code 4 (commonly "Not Found") in addition to the "Not Found" string in the response

## Testing
- The workflow run that failed: https://github.com/CloudWaddie/actions-agent/actions/runs/22044223064
- Manually deleted the orphaned branch `fix/fork-cleanup-debugging` from the fork