### PR TITLE
fix(workflow): skip fork cleanup gracefully when GH_PAT is missing

### DIFF
--- a/.github/workflows/fork-cleanup.yml
+++ b/.github/workflows/fork-cleanup.yml
@@ -14,15 +14,25 @@ jobs:
     
     steps:
       - name: Check GH_PAT secret
+        id: check_secret
         run: |
           if [ -z "${{ secrets.GH_PAT }}" ]; then
-            echo "ERROR: GH_PAT secret is not set!"
-            exit 1
+            echo "WARNING: GH_PAT secret is not set!"
+            echo "The workflow cannot clean up fork branches without GH_PAT."
+            echo "To enable branch cleanup:"
+            echo "1. Go to repository Settings → Secrets and variables → Actions"
+            echo "2. Add a new secret named 'GH_PAT'"
+            echo "3. Use a Personal Access Token with 'repo' scope"
+            echo ""
+            echo "For now, skipping cleanup..."
+            echo "secret_set=false" >> $GITHUB_OUTPUT
           else
             echo "GH_PAT secret is set"
+            echo "secret_set=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Verify authentication
+        if: steps.check_secret.outputs.secret_set == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -31,6 +41,7 @@ jobs:
           echo "========================================"
           
       - name: Cleanup fork branch after PR merge
+        if: steps.check_secret.outputs.secret_set == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |


### PR DESCRIPTION
## Summary

- Fix workflow failure when GH_PAT secret is not set
- Workflow now skips fork branch cleanup instead of failing with an error
- Provides clear instructions on how to set up GH_PAT secret in the workflow logs
- Adds conditional execution for auth verification and cleanup steps

## Root Cause

The workflow run 22045226875 failed because `${{ secrets.GH_PAT }}` was resolving to an empty string. The workflow was exiting with error code 1 when the secret was missing.

## Changes

1. Added step ID `check_secret` to track whether GH_PAT is set
2. If GH_PAT is missing, output a warning with setup instructions and set `secret_set=false`
3. Added conditional execution (`if: steps.check_secret.outputs.secret_set == 'true'`) to:
   - Skip authentication verification when no GH_PAT
   - Skip fork branch cleanup when no GH_PAT

## How to Test

1. Merge this PR - the workflow should complete successfully (with a warning about missing GH_PAT if not set)
2. If GH_PAT is set in repository secrets, the branch should be cleaned up from the fork

## Optional

To enable fork branch cleanup, add a GH_PAT secret to the repository:
1. Go to Settings → Secrets and variables → Actions
2. Add a new secret named `GH_PAT`
3. Use a Personal Access Token with `repo` scope