### PR TITLE
fix: improve GH_PAT detection with better debug logging

### DIFF
--- a/.github/workflows/fork-cleanup.yml
+++ b/.github/workflows/fork-cleanup.yml
@@ -11,13 +11,18 @@ jobs:
     
     permissions:
       contents: write
+      pull-requests: write
     
     steps:
       - name: Check GH_PAT secret
         id: check_secret
         run: |
-          if [ -z "${{ secrets.GH_PAT }}" ]; then
-            echo "WARNING: GH_PAT secret is not set!"
+          echo "=== DEBUG: GH_PAT Secret Check ==="
+          echo "Secret value length: ${#GH_PAT}"
+          echo "Secret first 4 chars: ${GH_PAT:0:4}"
+          
+          if [ -z "$GH_PAT" ]; then
+            echo "WARNING: GH_PAT secret is not set or is empty!"
             echo "The workflow cannot clean up fork branches without GH_PAT."
             echo "To enable branch cleanup:"
             echo "1. Go to repository Settings → Secrets and variables → Actions"
@@ -27,9 +32,11 @@ jobs:
             echo "For now, skipping cleanup..."
             echo "secret_set=false" >> $GITHUB_OUTPUT
           else
-            echo "GH_PAT secret is set"
+            echo "GH_PAT secret is set (length: ${#GH_PAT})"
             echo "secret_set=true" >> $GITHUB_OUTPUT
           fi
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
 
       - name: Verify authentication
         if: steps.check_secret.outputs.secret_set == 'true'


### PR DESCRIPTION
## Summary

- Improves GH_PAT detection by passing secret through environment variable for more accurate length checking
- Shows secret length and first 4 chars in debug output to help diagnose empty secret issues
- Adds `pull-requests: write` permission to workflow
- Helps investigate why GH_PAT appears empty in fork-cleanup workflow

## Root Cause

The previous workflow used `${{ secrets.GH_PAT }}` directly in a shell condition which may not accurately detect empty secrets. This fix passes the secret through an environment variable first to get more accurate debugging information.

## Testing

When merged, the workflow will now show:
- Secret value length
- First 4 characters of the secret (useful for identifying which token is being used)

This will help debug why the GH_PAT appears empty in the fork-cleanup workflow.