### PR TITLE
fix: use pull_request_target to enable secrets access for fork PR cleanup

### DIFF
--- a/.github/workflows/fork-cleanup.yml
+++ b/.github/workflows/fork-cleanup.yml
@@ -1,7 +1,7 @@
 name: Fork Branch Cleanup
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:


### PR DESCRIPTION
## Summary

The fork cleanup workflow was not detecting the `GH_PAT` secret because GitHub Actions does not pass secrets to workflows triggered by fork PRs.

### Root Cause

When a workflow is triggered by a pull request from a forked repository, GitHub runs it with **read-only permissions and no secrets access** - even though the workflow runs in the base repository context. This is a security measure to prevent malicious PRs from exfiltrating secrets.

Looking at the action run logs:
- `Secret source: None` 
- `GITHUB_TOKEN Permissions: Contents: read, Metadata: read, PullRequests: read`

### Fix

Changed from `pull_request` to `pull_request_target` event. This runs the workflow in the base repository context with full permissions and secrets access, allowing the cleanup to work properly.

```diff
-  pull_request:
+  pull_request_target:
```

### Security Note

`pull_request_target` gives full repo access to anyone who opens a PR. However, this workflow:
1. Only runs on PR merge (`if: github.event.pull_request.merged == true`)
2. Only cleans up branches from the `cloudwaddie-agent` fork
3. Uses explicit checks before performing any operations

This is the standard approach for workflows that need secrets access for fork PR cleanup.