### PR TITLE
Remove template, add copy-paste workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # actions-agent (CloudWaddie Agent)
 
-A GitHub **workflow template** that runs **cloudwaddie-agent** (an autonomous bot made by CloudWaddie) on @cloudwaddie-agent mentions in issue/PR comments.
+GitHub Actions workflows that run **cloudwaddie-agent** (an autonomous bot made by CloudWaddie) on @cloudwaddie-agent mentions in issue/PR comments.
 
 ## What it does
 - Listens for **issue/PR comments** that mention `@cloudwaddie-agent`
@@ -8,12 +8,21 @@ A GitHub **workflow template** that runs **cloudwaddie-agent** (an autonomous bo
 - Uses free OpenCode models (no authentication required by default)
 - Posts a helpful comment back via `gh`
 
-## Setup
-1. **Create a repo from this template** (or copy the workflow file).
-2. Add repo secrets:
+## Quick Setup
+
+### Copy/Paste Workflows (Recommended)
+
+Copy the workflow files from the [`workflows/`](workflows/) folder in this repository:
+
+1. **Copy these files to your `.github/workflows/` folder:**
+   - [`workflows/fork-cleanup.yml`](workflows/fork-cleanup.yml) - Cleans up fork branches after PR merge
+   - [`workflows/cloudwaddie-agent.yml`](workflows/cloudwaddie-agent.yml) - Main agent workflow
+
+2. **Add repo secrets:**
    - `GH_PAT` — GitHub PAT with repo scope
    - `OPENCODE_AUTH_JSON` — (optional) your OpenCode auth JSON for premium models
-3. Ensure the workflow file is enabled.
+
+3. **Enable the workflow** in your repo's Actions tab.
 
 ## Security Features
 - **Write workflow permissions** (`contents: write`, `pull-requests: write`) for fork and PR workflow
@@ -26,3 +35,101 @@ A GitHub **workflow template** that runs **cloudwaddie-agent** (an autonomous bo
 - Uses **free OpenCode models** by default (opencode/big-pickle)
 - Authentication is optional - works with free models out of the box
 - The bot **always posts at least one comment** explaining what it did or found
+
+## Setup Details
+
+### Configure Repository Secrets
+
+Go to your repository's **Settings → Secrets and variables → Actions** and add the following secrets:
+
+#### Required Secret: `GH_PAT`
+
+**Purpose**: Allows the bot to read issues/PRs and post comments.
+
+**Steps to create**:
+1. Go to https://github.com/settings/tokens/new
+2. Select **"Classic"** token (not fine-grained)
+3. Give it a descriptive name (e.g., "cloudwaddie-agent-bot")
+4. Set expiration (recommend: no expiration for persistent bots)
+5. Select scopes:
+   - ✅ `repo` (Full control of private repositories)
+   - ✅ `workflow` (Update GitHub Action workflows)
+6. Click **"Generate token"**
+7. Copy the token (you won't see it again!)
+8. In your repo → Settings → Secrets → Actions → **New repository secret**
+9. Name: `GH_PAT`
+10. Value: Paste the token
+11. Click **Add secret**
+
+#### Optional Secret: `OPENCODE_AUTH_JSON`
+
+**Purpose**: Use premium OpenCode models (Claude, GPT, etc.) instead of free models.
+
+**Without this secret**: The bot uses free OpenCode models like `opencode/big-pickle` (works fine for basic tasks).
+
+**With this secret**: The bot can use premium models for better responses.
+
+**Steps to get your OpenCode auth JSON**:
+
+1. **Install OpenCode CLI** (on your local machine):
+   ```bash
+   curl -fsSL https://opencode.ai/install | bash
+   ```
+
+2. **Authenticate with your providers** (pick at least one):
+   
+   **For Claude (Anthropic)**:
+   ```bash
+   opencode auth anthropic
+   ```
+   
+   **For OpenAI (ChatGPT)**:
+   ```bash
+   opencode auth openai
+   ```
+   
+   **For Google Gemini**:
+   ```bash
+   opencode auth google
+   ```
+
+3. **Extract the auth JSON**:
+   
+   **On Linux/Mac**:
+   ```bash
+   cat ~/.local/share/opencode/auth.json
+   ```
+   
+   **On Windows**:
+   ```powershell
+   type %USERPROFILE%\AppData\Local\opencode\auth.json
+   ```
+
+4. **Add to repository secrets**:
+   - Go to your repo → Settings → Secrets → Actions
+   - Click **New repository secret**
+   - Name: `OPENCODE_AUTH_JSON`
+   - Value: Paste the entire JSON
+   - Click **Add secret**
+
+## Troubleshooting
+
+### Bot doesn't respond
+
+**Check**:
+1. Did you mention `@cloudwaddie-agent` in your comment?
+2. Are you a contributor to the repository?
+3. Is the workflow file enabled? (Actions → Workflows → CloudWaddie Agent → Enable)
+4. Check the Actions tab for workflow run logs
+
+### Bot fails with authentication errors
+
+**Solution**:
+1. Verify the PAT token has the required scopes:
+   - ✅ `repo` (Full control of private repositories)
+   - ✅ `workflow` (Update GitHub Action workflows)
+2. If the token is expired or has wrong scopes, create a new one
+
+## License
+
+This workflow is provided as-is for public use.

--- a/template.json
+++ b/template.json
@@ -1,6 +1,0 @@
-{
-  "name": "actions-agent",
-  "description": "GitHub Actions template to run cloudwaddie-agent (by CloudWaddie) on @cloudwaddie-agent mentions",
-  "categories": ["automation", "bot", "ai"],
-  "filePatterns": [".github/workflows/cloudwaddie-agent.yml", "README.md"]
-}

--- a/workflows/cloudwaddie-agent.yml
+++ b/workflows/cloudwaddie-agent.yml
@@ -1,0 +1,587 @@
+name: CloudWaddie Agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: "Custom prompt"
+        required: false
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    # @cloudwaddie-agent mention only (contributors, exclude self)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body || '', '@cloudwaddie-agent') &&
+       (github.event.comment.user.login || '') != 'cloudwaddie-agent' &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association || '')) ||
+      (github.event_name == 'issues' &&
+       contains(github.event.issue.body || '', '@cloudwaddie-agent') &&
+       (github.event.issue.user.login || '') != 'cloudwaddie-agent' &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.issue.author_association || '')) ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.body || '', '@cloudwaddie-agent') &&
+       (github.event.pull_request.user.login || '') != 'cloudwaddie-agent' &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association || ''))
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      # Checkout with cloudwaddie-agent's PAT
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_PAT }}
+          fetch-depth: 0
+
+      # Git config - commits as cloudwaddie-agent
+      - name: Configure Git as cloudwaddie-agent
+        run: |
+          git config user.name "cloudwaddie-agent"
+          git config user.email "cloudwaddie-agent@users.noreply.github.com"
+
+      # gh CLI auth as cloudwaddie-agent
+      - name: Authenticate gh CLI as cloudwaddie-agent
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          # GH_TOKEN environment variable is automatically used by gh CLI
+          # Verify authentication works
+          gh auth status || echo "Using GH_TOKEN environment variable for authentication"
+
+      - name: Ensure tmux is available (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          if ! command -v tmux >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends tmux
+          fi
+          tmux -V
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Checkout oh-my-opencode dev branch
+        uses: actions/checkout@v6
+        with:
+          repository: code-yeongyu/oh-my-opencode
+          ref: dev
+          path: oh-my-opencode
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            oh-my-opencode/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('oh-my-opencode/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Get OpenCode latest version
+        id: opencode-version
+        run: |
+          # Fetch version with validation
+          VERSION=$(curl -s https://opencode.ai/api/version 2>/dev/null | head -n 1 | tr -cd '[:alnum:].-')
+      
+          # Validate: ensure it looks like a version string (not HTML/CSS)
+          if [[ ! "$VERSION" =~ ^[a-zA-Z0-9._-]+$ ]] || [[ -z "$VERSION" ]]; then
+            echo "VERSION environment variable is invalid or empty."
+            exit 1
+          fi
+
+      - name: Cache OpenCode CLI
+        uses: actions/cache@v5
+        with:
+          path: ~/.opencode
+          key: ${{ runner.os }}-opencode-${{ steps.opencode-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-opencode-
+
+      - name: Cache oh-my-opencode dist
+        uses: actions/cache@v5
+        with:
+          path: oh-my-opencode/dist
+          key: ${{ runner.os }}-omo-dist-${{ hashFiles('oh-my-opencode/src/**/*.ts', 'oh-my-opencode/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-omo-dist-
+
+      # Build oh-my-opencode
+      - name: Build oh-my-opencode
+        working-directory: oh-my-opencode
+        run: |
+          # Skip build if dist already cached and valid
+          if [ -d "dist" ] && [ "$(ls -A dist)" ]; then
+            echo "Using cached dist folder"
+          else
+            bun install
+            bun run build
+          fi
+
+      # Install OpenCode + configure local plugin + auth in single step
+      - name: Setup OpenCode with oh-my-opencode
+        env:
+          OPENCODE_AUTH_JSON: ${{ secrets.OPENCODE_AUTH_JSON }}
+        run: |
+          export PATH="$HOME/.opencode/bin:$PATH"
+
+          # Install OpenCode (skip if cached)
+          if ! command -v opencode &>/dev/null; then
+            echo "Installing OpenCode..."
+            curl -fsSL https://opencode.ai/install -o /tmp/opencode-install.sh
+            
+            # Try default installer first, fallback to re-download if it fails
+            if file /tmp/opencode-install.sh | grep -q "shell script\|text"; then
+              if ! bash /tmp/opencode-install.sh 2>&1; then
+                echo "Default installer failed, trying direct install..."
+                bash <(curl -fsSL https://opencode.ai/install)
+              fi
+            else
+              echo "Download corrupted, trying direct install..."
+              bash <(curl -fsSL https://opencode.ai/install)
+            fi
+          fi
+          opencode --version
+
+          # Run local oh-my-opencode install (uses built dist)
+          bun run oh-my-opencode/dist/cli/index.js install --no-tui --claude=no --openai=no --gemini=no --copilot=no
+
+          # Override plugin to use local file reference
+          OPENCODE_JSON=~/.config/opencode/opencode.json
+          REPO_PATH=$(pwd)/oh-my-opencode
+          jq --arg path "file://$REPO_PATH/src/index.ts" '
+            .plugin = [.plugin[] | select(. != "oh-my-opencode")] + [$path]
+          ' "$OPENCODE_JSON" > /tmp/oc.json && mv /tmp/oc.json "$OPENCODE_JSON"
+
+          # Configure auth if provided, otherwise use free models
+          if [[ -n "$OPENCODE_AUTH_JSON" ]]; then
+            mkdir -p ~/.local/share/opencode
+            echo "$OPENCODE_AUTH_JSON" > ~/.local/share/opencode/auth.json
+            chmod 600 ~/.local/share/opencode/auth.json
+          else
+            echo "No auth provided - using free OpenCode models"
+            # Set default model to free tier
+            jq '.model = "opencode/big-pickle"' "$OPENCODE_JSON" > /tmp/oc.json && mv /tmp/oc.json "$OPENCODE_JSON"
+          fi
+
+          # Configure oh-my-opencode prompt_append with ultrawork mode
+          OMO_JSON=~/.config/opencode/oh-my-opencode.json
+          PROMPT_APPEND=$(cat << 'PROMPT_EOF'
+          <ultrawork-mode>
+          [CODE RED] Maximum precision required. Ultrathink before acting.
+
+          YOU MUST LEVERAGE ALL AVAILABLE AGENTS TO THEIR FULLEST POTENTIAL.
+          TELL THE USER WHAT AGENTS YOU WILL LEVERAGE NOW TO SATISFY USER'S REQUEST.
+
+          ## AGENT UTILIZATION PRINCIPLES (by capability, not by name)
+          - **Codebase Exploration**: Spawn exploration agents using BACKGROUND TASKS for file patterns, internal implementations, project structure
+          - **Documentation & References**: Use librarian-type agents via BACKGROUND TASKS for API references, examples, external library docs
+          - **Planning & Strategy**: For implementation tasks, spawn a dedicated planning agent for work breakdown (not needed for simple questions/investigations)
+          - **High-IQ Reasoning**: Leverage specialized agents for architecture decisions, code review, strategic planning
+          - **Frontend/UI Tasks**: Delegate to UI-specialized agents for design and implementation
+
+          ## EXECUTION RULES
+          - **TODO**: Track EVERY step. Mark complete IMMEDIATELY after each.
+          - **PARALLEL**: Fire independent agent calls simultaneously via background_task - NEVER wait sequentially.
+          - **BACKGROUND FIRST**: Use background_task for exploration/research agents (10+ concurrent if needed).
+          - **VERIFY**: Re-read request after completion. Check ALL requirements met before reporting done.
+          - **DELEGATE**: Don't do everything yourself - orchestrate specialized agents for their strengths.
+
+          ## WORKFLOW
+          1. Analyze the request and identify required capabilities
+          2. Spawn exploration/librarian agents via background_task in PARALLEL (10+ if needed)
+          3. Always Use Plan agent with gathered context to create detailed work breakdown
+          4. Execute with continuous verification against original requirements
+
+          ## TDD (if test infrastructure exists)
+
+          1. Write spec (requirements)
+          2. Write tests (failing)
+          3. RED: tests fail
+          4. Implement minimal code
+          5. GREEN: tests pass
+          6. Refactor if needed (must stay green)
+          7. Next feature, repeat
+
+          ## ZERO TOLERANCE FAILURES
+          - **NO Scope Reduction**: Never make "demo", "skeleton", "simplified", "basic" versions - deliver FULL implementation
+          - **NO MockUp Work**: When user asked you to do "port A", you must "port A", fully, 100%. No Extra feature, No reduced feature, no mock data, fully working 100% port.
+          - **NO Partial Completion**: Never stop at 60-80% saying "you can extend this..." - finish 100%
+          - **NO Assumed Shortcuts**: Never skip requirements you deem "optional" or "can be added later"
+          - **NO Premature Stopping**: Never declare done until ALL TODOs are completed and verified
+          - **NO TEST DELETION**: Never delete or skip failing tests to make the build pass. Fix the code, not the tests.
+
+          THE USER ASKED FOR X. DELIVER EXACTLY X. NOT A SUBSET. NOT A DEMO. NOT A STARTING POINT.
+
+          </ultrawork-mode>
+
+          ---
+
+
+          [analyze-mode]
+          ANALYSIS MODE. Gather context before diving deep:
+
+          CONTEXT GATHERING (parallel):
+          - 1-2 explore agents (codebase patterns, implementations)
+          - 1-2 librarian agents (if external library involved)
+          - Direct tools: Grep, AST-grep, LSP for targeted searches
+
+          IF COMPLEX - DO NOT STRUGGLE ALONE. Consult specialists:
+          - **Oracle**: Conventional problems (architecture, debugging, complex logic)
+          - **Artistry**: Non-conventional problems (different approach needed)
+
+          SYNTHESIZE findings before proceeding.
+
+          ---
+
+          ## GitHub Actions Environment
+
+          You are `cloudwaddie-agent` in GitHub Actions.
+
+          ### CRITICAL: GitHub Comments = Your ONLY Output
+
+          User CANNOT see console. Post everything via `gh issue comment` or `gh pr comment`.
+
+          ### Comment Formatting (CRITICAL)
+
+          **ALWAYS use heredoc syntax for comments containing code references, backticks, or multiline content:**
+
+          ```bash
+          gh issue comment <number> --body "$(cat <<'EOF'
+          Your comment with `backticks` and code references preserved here.
+          Multiple lines work perfectly.
+          EOF
+          )"
+          ```
+
+          **NEVER use direct quotes with backticks** (shell will interpret them as command substitution):
+          ```bash
+          # WRONG - backticks disappear:
+          gh issue comment 123 --body "text with `code`"
+          
+          # CORRECT - backticks preserved:
+          gh issue comment 123 --body "$(cat <<'EOF'
+          text with `code`
+          EOF
+          )"
+          ```
+
+          ### GitHub Markdown Rules (MUST FOLLOW)
+
+          **Code blocks MUST have EXACTLY 3 backticks and language identifier:**
+          - CORRECT: ` ```bash ` ... ` ``` `
+          - WRONG: ` ``` ` (no language), ` ```` ` (4 backticks), ` `` ` (2 backticks)
+          
+          **Every opening ` ``` ` MUST have a closing ` ``` ` on its own line:**
+          ```
+          ```bash
+          code here
+          ```
+          ```
+          
+          **NO trailing backticks or spaces after closing ` ``` `**
+          
+          **For inline code, use SINGLE backticks:** `code` not ```code```
+          
+          **Lists inside code blocks break rendering - avoid them or use plain text**
+
+          ### Rules
+          - EVERY response = GitHub comment (use heredoc for proper escaping)
+          - Code changes = PR (never push main/master)
+          - Setup: bun install first
+          - Acknowledge immediately, report when done
+
+          ### Git Config
+          - user.name: cloudwaddie-agent
+          - user.email: cloudwaddie-agent@users.noreply.github.com
+          PROMPT_EOF
+          )
+          jq --arg append "$PROMPT_APPEND" '.agents.Sisyphus.prompt_append = $append' "$OMO_JSON" > /tmp/omo.json && mv /tmp/omo.json "$OMO_JSON"
+
+          cat "$OPENCODE_JSON"
+
+      # Collect context
+      - name: Collect Context
+        id: context
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          COMMENT_ID_VAL: ${{ github.event.comment.id }}
+        run: |
+          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+            # Comment on issue or PR
+            ISSUE_NUM="${{ github.event.issue.number }}"
+            AUTHOR="$COMMENT_AUTHOR"
+            COMMENT_ID="$COMMENT_ID_VAL"
+            USER_COMMENT="$COMMENT_BODY"
+            
+            # Check if PR or Issue
+            ISSUE_DATA=$(gh api "repos/$REPO/issues/${ISSUE_NUM}")
+            TITLE=$(echo "$ISSUE_DATA" | jq -r '.title')
+            
+            if echo "$ISSUE_DATA" | jq -e '.pull_request' > /dev/null; then
+              echo "type=pr" >> $GITHUB_OUTPUT
+            else
+              echo "type=issue" >> $GITHUB_OUTPUT
+            fi
+            echo "number=${ISSUE_NUM}" >> $GITHUB_OUTPUT
+            echo "title=${TITLE}" >> $GITHUB_OUTPUT
+            echo "comment<<EOF" >> $GITHUB_OUTPUT
+            echo "$USER_COMMENT" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "author=$AUTHOR" >> $GITHUB_OUTPUT
+            echo "comment_id=$COMMENT_ID" >> $GITHUB_OUTPUT
+            
+          elif [[ "$EVENT_NAME" == "issues" ]]; then
+            # Issue opened/edited
+            ISSUE_NUM="${{ github.event.issue.number }}"
+            AUTHOR="${{ github.event.issue.user.login }}"
+            TITLE="${{ github.event.issue.title }}"
+            
+            # Use gh api to fetch body reliably (handles multiline, special chars)
+            USER_COMMENT=$(gh api "repos/$REPO/issues/${ISSUE_NUM}" --jq '.body // ""')
+            
+            echo "type=issue" >> $GITHUB_OUTPUT
+            echo "number=${ISSUE_NUM}" >> $GITHUB_OUTPUT
+            echo "title=${TITLE}" >> $GITHUB_OUTPUT
+            echo "comment<<EOF" >> $GITHUB_OUTPUT
+            echo "$USER_COMMENT" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "author=$AUTHOR" >> $GITHUB_OUTPUT
+            echo "comment_id=" >> $GITHUB_OUTPUT
+            
+          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+            # PR opened/edited
+            PR_NUM="${{ github.event.pull_request.number }}"
+            AUTHOR="${{ github.event.pull_request.user.login }}"
+            TITLE="${{ github.event.pull_request.title }}"
+            
+            # Use gh api to fetch body reliably (handles multiline, special chars)
+            USER_COMMENT=$(gh api "repos/$REPO/pulls/${PR_NUM}" --jq '.body // ""')
+            
+            echo "type=pr" >> $GITHUB_OUTPUT
+            echo "number=${PR_NUM}" >> $GITHUB_OUTPUT
+            echo "title=${TITLE}" >> $GITHUB_OUTPUT
+            echo "comment<<EOF" >> $GITHUB_OUTPUT
+            echo "$USER_COMMENT" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "author=$AUTHOR" >> $GITHUB_OUTPUT
+            echo "comment_id=" >> $GITHUB_OUTPUT
+            
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            # Manual workflow trigger
+            echo "type=dispatch" >> $GITHUB_OUTPUT
+            echo "number=" >> $GITHUB_OUTPUT
+            echo "title=Manual Workflow Run" >> $GITHUB_OUTPUT
+            echo "author=${{ github.actor }}" >> $GITHUB_OUTPUT
+            echo "comment_id=" >> $GITHUB_OUTPUT
+            echo "comment<<EOF" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+      # Add :eyes: reaction (as cloudwaddie-agent)
+      - name: Add eyes reaction
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          if [[ -n "${{ steps.context.outputs.comment_id }}" ]]; then
+            # React to comment
+            gh api "/repos/${{ github.repository }}/issues/comments/${{ steps.context.outputs.comment_id }}/reactions" \
+              -X POST -f content="eyes" || true
+          elif [[ -n "${{ steps.context.outputs.number }}" ]]; then
+            # React to issue/PR itself
+            gh api "/repos/${{ github.repository }}/issues/${{ steps.context.outputs.number }}/reactions" \
+              -X POST -f content="eyes" || true
+          fi
+
+      - name: Run oh-my-opencode
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          USER_COMMENT: ${{ steps.context.outputs.comment }}
+          COMMENT_AUTHOR: ${{ steps.context.outputs.author }}
+          CONTEXT_TYPE: ${{ steps.context.outputs.type }}
+          CONTEXT_NUMBER: ${{ steps.context.outputs.number }}
+          CONTEXT_TITLE: ${{ steps.context.outputs.title }}
+          REPO_NAME: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          export PATH="$HOME/.opencode/bin:$PATH"
+
+          PROMPT=$(cat <<'PROMPT_EOF'
+          [analyze-mode]
+          ANALYSIS MODE. Gather context before diving deep:
+
+          CONTEXT GATHERING (parallel):
+          - 1-2 explore agents (codebase patterns, implementations)
+          - 1-2 librarian agents (if external library involved)
+          - Direct tools: Grep, AST-grep, LSP for targeted searches
+
+          IF COMPLEX - DO NOT STRUGGLE ALONE. Consult specialists:
+          - **Oracle**: Conventional problems (architecture, debugging, complex logic)
+          - **Artistry**: Non-conventional problems (different approach needed)
+
+          SYNTHESIZE findings before proceeding.
+
+          ---
+
+          Your username is @cloudwaddie-agent, mentioned by @AUTHOR_PLACEHOLDER in REPO_PLACEHOLDER.
+
+          ## Context
+          - Title: TITLE_PLACEHOLDER
+          - Type: TYPE_PLACEHOLDER
+          - Number: #NUMBER_PLACEHOLDER
+          - Repository: REPO_PLACEHOLDER
+          - Default Branch: BRANCH_PLACEHOLDER
+
+          ## User's Request
+          COMMENT_PLACEHOLDER
+
+          ---
+
+          ## CRITICAL: First Steps (MUST DO BEFORE ANYTHING ELSE)
+
+          ### [CODE RED] MANDATORY OUTPUT REQUIREMENT
+
+          **YOU MUST POST AT LEAST ONE COMMENT. SILENT COMPLETION = FAILURE.**
+
+          - Every task MUST result in at least one comment via `gh issue comment` or `gh pr comment`
+          - Explain what you found, what you did, or why you couldn't complete the task
+          - NEVER finish without posting a comment - the user cannot see console output
+          - If you have nothing to report, comment to acknowledge you saw the request and explain why no action was needed
+
+          ---
+
+          ### [CODE RED] MANDATORY CONTEXT READING - ZERO EXCEPTIONS
+
+          **YOU MUST READ FULL CONVERSATION HISTORY. NO SHORTCUTS.**
+
+          The workflow provides basic metadata above, but you MUST fetch the complete conversation:
+
+          **For Issues** - Run this command FIRST:
+          ```bash
+          gh issue view NUMBER_PLACEHOLDER --comments
+          ```
+
+          **For PRs** - Run ALL THREE commands FIRST:
+          ```bash
+          gh pr view NUMBER_PLACEHOLDER --comments
+          gh api repos/REPO_PLACEHOLDER/pulls/NUMBER_PLACEHOLDER/comments
+          gh api repos/REPO_PLACEHOLDER/pulls/NUMBER_PLACEHOLDER/reviews
+          ```
+
+          **WHAT TO EXTRACT:**
+          1. **Original issue/PR body** - The initial description (TRUE requirement)
+          2. **ALL comments** - Additional context, clarifications, feedback
+          3. **Previous attempts** - What was tried before, what failed, why
+          4. **Decisions & reasoning** - Choices made in the conversation
+          5. **Linked references** - Related issues, PRs, external links
+          6. **The specific request** - What the person who mentioned you wants
+
+          **WHY THIS IS CRITICAL:**
+          - The workflow only passes basic metadata (title, number, type)
+          - You need the FULL conversation to understand context
+          - Previous comments may contain critical information
+          - The person who mentioned you might be replying to earlier discussion
+
+          **FAILURE TO READ = GUARANTEED WRONG ANSWER**
+          You WILL miss requirements. You WILL repeat mistakes. You WILL waste everyone's time.
+
+          ---
+
+          ### Step 2: CREATE TODOS IMMEDIATELY
+
+          After reading the full conversation, create your todo list using todo tools:
+
+          1. **First todo**: "Summarize issue/PR context and requirements"
+          2. **Break down work** into atomic, verifiable steps
+          3. **GIT WORKFLOW** (for implementation tasks):
+             
+              **GIT WORKFLOW**: Use fork-based workflow for all changes:
+              1. Fork the repo: `gh repo fork --remote=false` (creates fork under cloudwaddie-agent account)
+              2. Sync fork main branch from upstream BEFORE creating new branch:
+                 - `git remote add upstream https://github.com/CloudWaddie/actions-agent.git` (if not already added)
+                 - `git fetch upstream`
+                 - `git checkout -b feature-branch upstream/main` (branch off fresh upstream main, NOT stale fork main)
+              3. Commit changes with clear, atomic commits
+              4. Push to YOUR FORK: `git push https://github.com/cloudwaddie-agent/actions-agent.git feature-branch`
+              5. Create PR from fork to upstream: `gh pr create --repo CloudWaddie/actions-agent --head cloudwaddie-agent:feature-branch --base main`
+
+              **IMPORTANT**: Always sync from upstream main before creating branches. Never branch from the fork's main (which may be stale).
+
+          4. **Plan everything BEFORE starting** any work
+
+          ---
+
+          ## Workflow
+
+          1. **READ** full conversation with `gh` commands above
+          2. **CREATE TODOS** to plan all work
+          3. **INVESTIGATE** and satisfy the request
+          4. **IF implementation requested**: Use plan agent, create todos, make PR to `BRANCH_PLACEHOLDER` branch
+          5. **ALWAYS COMMENT**: Report results with `gh issue comment NUMBER_PLACEHOLDER` or `gh pr comment NUMBER_PLACEHOLDER`
+
+          Silent completion is NOT acceptable. You MUST comment.
+          PROMPT_EOF
+          )
+
+          PROMPT="${PROMPT//AUTHOR_PLACEHOLDER/$COMMENT_AUTHOR}"
+          PROMPT="${PROMPT//REPO_PLACEHOLDER/$REPO_NAME}"
+          PROMPT="${PROMPT//TYPE_PLACEHOLDER/$CONTEXT_TYPE}"
+          PROMPT="${PROMPT//NUMBER_PLACEHOLDER/$CONTEXT_NUMBER}"
+          PROMPT="${PROMPT//TITLE_PLACEHOLDER/$CONTEXT_TITLE}"
+          PROMPT="${PROMPT//BRANCH_PLACEHOLDER/$DEFAULT_BRANCH}"
+          PROMPT="${PROMPT//COMMENT_PLACEHOLDER/$USER_COMMENT}"
+          
+          stdbuf -oL -eL bun run oh-my-opencode/dist/cli/index.js run "$PROMPT"
+
+      - name: Update reaction
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          if [[ -n "${{ steps.context.outputs.comment_id }}" ]]; then
+            REACTION_ID=$(gh api "/repos/${{ github.repository }}/issues/comments/${{ steps.context.outputs.comment_id }}/reactions" \
+              --jq '.[] | select(.content == "eyes" and .user.login == "cloudwaddie-agent") | .id' | head -1)
+            if [[ -n "$REACTION_ID" ]]; then
+              gh api -X DELETE "/repos/${{ github.repository }}/issues/comments/${{ steps.context.outputs.comment_id }}/reactions/${REACTION_ID}" || true
+            fi
+
+            gh api "/repos/${{ github.repository }}/issues/comments/${{ steps.context.outputs.comment_id }}/reactions" \
+              -X POST -f content="+1" || true
+          fi
+
+          if [[ "${{ github.event_name }}" == "issues" ]] || [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            if [[ "${{ steps.context.outputs.type }}" == "pr" ]]; then
+              REACTION_ID=$(gh api "/repos/${{ github.repository }}/pulls/${{ steps.context.outputs.number }}/reactions" \
+                --jq '.[] | select(.content == "eyes" and .user.login == "cloudwaddie-agent") | .id' | head -1)
+              if [[ -n "$REACTION_ID" ]]; then
+                gh api -X DELETE "/repos/${{ github.repository }}/pulls/${{ steps.context.outputs.number }}/reactions/${REACTION_ID}" || true
+              fi
+              gh api "/repos/${{ github.repository }}/pulls/${{ steps.context.outputs.number }}/reactions" \
+                -X POST -f content="+1" || true
+            else
+              REACTION_ID=$(gh api "/repos/${{ github.repository }}/issues/${{ steps.context.outputs.number }}/reactions" \
+                --jq '.[] | select(.content == "eyes" and .user.login == "cloudwaddie-agent") | .id' | head -1)
+              if [[ -n "$REACTION_ID" ]]; then
+                gh api -X DELETE "/repos/${{ github.repository }}/issues/${{ steps.context.outputs.number }}/reactions/${REACTION_ID}" || true
+              fi
+              gh api "/repos/${{ github.repository }}/issues/${{ steps.context.outputs.number }}/reactions" \
+                -X POST -f content="+1" || true
+            fi
+          fi
+

--- a/workflows/fork-cleanup.yml
+++ b/workflows/fork-cleanup.yml
@@ -1,0 +1,104 @@
+name: Fork Branch Cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+      - name: Check GH_PAT secret
+        id: check_secret
+        run: |
+          echo "=== DEBUG: GH_PAT Secret Check ==="
+          echo "Secret value length: ${#GH_PAT}"
+          echo "Secret first 4 chars: ${GH_PAT:0:4}"
+          
+          if [ -z "$GH_PAT" ]; then
+            echo "WARNING: GH_PAT secret is not set or is empty!"
+            echo "The workflow cannot clean up fork branches without GH_PAT."
+            echo "To enable branch cleanup:"
+            echo "1. Go to repository Settings → Secrets and variables → Actions"
+            echo "2. Add a new secret named 'GH_PAT'"
+            echo "3. Use a Personal Access Token with 'repo' scope"
+            echo ""
+            echo "For now, skipping cleanup..."
+            echo "secret_set=false" >> $GITHUB_OUTPUT
+          else
+            echo "GH_PAT secret is set (length: ${#GH_PAT})"
+            echo "secret_set=true" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+
+      - name: Verify authentication
+        if: steps.check_secret.outputs.secret_set == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          echo "=== Verifying GitHub Authentication ==="
+          gh auth status
+          echo "========================================"
+          
+      - name: Cleanup fork branch after PR merge
+        if: steps.check_secret.outputs.secret_set == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          # Get the branch name from the merged PR head
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          FORK_REPO="cloudwaddie-agent/${{ github.event.repository.name }}"
+          HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+          
+          echo "=== Fork Cleanup Debug Info ==="
+          echo "Branch name: $BRANCH_NAME"
+          echo "Fork repo: $FORK_REPO"
+          echo "Head repo: $HEAD_REPO"
+          echo "================================"
+          
+          # Only cleanup if the PR was from our fork
+          if [[ "$HEAD_REPO" == "$FORK_REPO" ]]; then
+            echo "Cleaning up fork branch: $BRANCH_NAME"
+            
+            # Delete the branch from the fork using gh API
+            # Note: Disable set -e to capture the exit code properly
+            echo "Deleting branch via API..."
+            set +e
+            RESPONSE=$(gh api "repos/$FORK_REPO/git/refs/heads/$BRANCH_NAME" -X DELETE 2>&1)
+            EXIT_CODE=$?
+            set -e
+            
+            echo "API Response: $RESPONSE"
+            echo "Exit code: $EXIT_CODE"
+            
+            if [ $EXIT_CODE -eq 0 ]; then
+              echo "Successfully deleted branch: $BRANCH_NAME"
+            elif echo "$RESPONSE" | grep -q "Not Found" || echo "$RESPONSE" | grep -q "404"; then
+              # Branch doesn't exist - that's OK
+              echo "Branch already deleted or does not exist (404)"
+            elif echo "$RESPONSE" | grep -qi "authentication\|GH_TOKEN\|credential"; then
+              # Authentication error - this is a real problem
+              echo "ERROR: Authentication failed. Please check GH_PAT secret."
+              echo "Error: $RESPONSE"
+              exit 1
+            elif [ $EXIT_CODE -eq 4 ]; then
+              # Exit code 4 could be various errors - check if it's something we can ignore
+              echo "Warning: gh api returned exit code 4. Response: $RESPONSE"
+              # Don't treat as success, but don't fail either
+            else
+              echo "Failed to delete branch. Exit code: $EXIT_CODE"
+              echo "Error: $RESPONSE"
+              exit 1
+            fi
+            
+            echo "Cleanup complete for branch: $BRANCH_NAME"
+          else
+            echo "Skipping cleanup - PR was not from fork ($HEAD_REPO != $FORK_REPO)"
+          fi


### PR DESCRIPTION
## Summary

- Removed `template.json` to stop being a GitHub template repository
- Updated README to remove template-specific language and add copy-paste instructions
- Added `workflows/` folder at root level with the workflow files for easy copying

Users can now copy/paste the workflows directly instead of forking the template.