### PR TITLE
Fix Gemini review issues - remove template, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # actions-agent (CloudWaddie Agent)
 
-A GitHub **workflow template** that runs **cloudwaddie-agent** (an autonomous bot made by CloudWaddie) on @cloudwaddie-agent mentions in issue/PR comments.
+A collection of GitHub **workflows** that run **cloudwaddie-agent** (an autonomous bot made by CloudWaddie) on @cloudwaddie-agent mentions in issue/PR comments.
 
 ## What it does
 - Listens for **issue/PR comments** that mention `@cloudwaddie-agent`
@@ -9,11 +9,20 @@ A GitHub **workflow template** that runs **cloudwaddie-agent** (an autonomous bo
 - Posts a helpful comment back via `gh`
 
 ## Setup
-1. **Create a repo from this template** (or copy the workflow file).
-2. Add repo secrets:
+
+### Copy/Paste Workflows (Recommended)
+
+Copy the workflow files from the [`.github/workflows/`](.github/workflows/) folder in this repository:
+
+1. **Copy these files to your `.github/workflows/` folder:**
+   - [`.github/workflows/fork-cleanup.yml`](.github/workflows/fork-cleanup.yml) - Cleans up fork branches after PR merge
+   - [`.github/workflows/cloudwaddie-agent.yml`](.github/workflows/cloudwaddie-agent.yml) - Main agent workflow
+
+2. **Add repo secrets:**
    - `GH_PAT` — GitHub PAT with repo scope
    - `OPENCODE_AUTH_JSON` — (optional) your OpenCode auth JSON for premium models
-3. Ensure the workflow file is enabled.
+
+3. **Enable the workflow** in your repository's Actions tab.
 
 ## Security Features
 - **Write workflow permissions** (`contents: write`, `pull-requests: write`) for fork and PR workflow

--- a/template.json
+++ b/template.json
@@ -1,6 +1,0 @@
-{
-  "name": "actions-agent",
-  "description": "GitHub Actions template to run cloudwaddie-agent (by CloudWaddie) on @cloudwaddie-agent mentions",
-  "categories": ["automation", "bot", "ai"],
-  "filePatterns": [".github/workflows/cloudwaddie-agent.yml", "README.md"]
-}


### PR DESCRIPTION
## Summary

Fixes the issues pointed out by Gemini Code Assist in PR #54:

1. **Removed `template.json`** - This stops the repo from being a GitHub template repository (addressing issue #53 "template gone")

2. **Updated README** - Removed template-specific language and added clear copy-paste instructions pointing to `.github/workflows/`

3. **Workflows stay in `.github/workflows/`** - No separate `workflows/` folder was created; workflows remain in the standard GitHub Actions location

### Changes

- **template.json**: Deleted
- **README.md**: Updated to explicitly point to `.github/workflows/` for copy/paste usage