### PR TITLE
fix: enable OpenAI/Copilot model selection when providers detected

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -191,6 +191,9 @@ jobs:
           if [[ -z "$OPENCODE_AUTH_JSON" ]]; then
             echo "No auth provided - using free OpenCode models"
             jq '.model = "opencode/big-pickle"' "$OPENCODE_JSON" > /tmp/oc.json && mv /tmp/oc.json "$OPENCODE_JSON"
+          elif [[ "$OPENAI_FLAG" == "--openai=yes" ]] || [[ "$COPILOT_FLAG" == "--copilot=yes" ]]; then
+            echo "OpenAI/Copilot available - using GPT-4o for Sisyphus"
+            jq '.model = "opencode/gpt-4o"' "$OPENCODE_JSON" > /tmp/oc.json && mv /tmp/oc.json "$OPENCODE_JSON"
           fi
 
           # Configure oh-my-opencode prompt_append with ultrawork mode


### PR DESCRIPTION
## Summary
- Add model configuration to use GPT-4o when OpenAI/Copilot is available (not Claude)

This fixes the issue where premium models weren't working correctly because the workflow was trying to use Claude models even when the user wanted to use OpenAI/Copilot.

## Changes
1. When OpenAI or Copilot is enabled in auth, configure the model to use `opencode/gpt-4o` instead of defaulting to Claude

## Related
- Fixes #56