### PR TITLE
fix: write auth.json to correct locations and clear all provider caches

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -165,7 +165,12 @@ jobs:
             echo "$OPENCODE_AUTH_JSON" > ~/.local/share/opencode/auth.json
             chmod 600 ~/.local/share/opencode/auth.json
 
+            mkdir -p ~/.local/share/opencode/storage
+            echo "$OPENCODE_AUTH_JSON" > ~/.local/share/opencode/storage/auth.json
+            chmod 600 ~/.local/share/opencode/storage/auth.json
+
             rm -rf ~/.cache/oh-my-opencode/connected-providers.json ~/.cache/oh-my-opencode/provider-models.json 2>/dev/null || true
+            rm -rf ~/.cache/opencode/connected-providers.json ~/.cache/opencode/provider-models.json 2>/dev/null || true
 
             if echo "$OPENCODE_AUTH_JSON" | jq -e '.anthropic' > /dev/null 2>&1; then
               CLAUDE_FLAG="--claude=yes"


### PR DESCRIPTION
## Summary

- Write auth.json to both `~/.local/share/opencode/auth.json` and `~/.local/share/opencode/storage/auth.json` to ensure OpenCode can find the credentials
- Clear both oh-my-opencode and OpenCode provider caches to ensure fresh provider detection at runtime

This fixes the issue where premium models weren't working because:
1. Auth wasn't being written to the correct location
2. Provider caches weren't being properly cleared, causing stale provider detection

With this fix, when you have `github-copilot` and `openai` in your `OPENCODE_AUTH_JSON`, the workflow will:
1. Correctly detect and enable those providers
2. Clear all caches so the providers are re-detected at runtime
3. OpenCode should automatically use github-copilot as the provider instead of anthropic