### PR TITLE
fix: use npm to get OpenCode version instead of deprecated API endpoint

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -93,14 +93,15 @@ jobs:
       - name: Get OpenCode latest version
         id: opencode-version
         run: |
-          # Fetch version with validation
-          VERSION=$(curl -s https://opencode.ai/api/version 2>/dev/null | head -n 1 | tr -cd '[:alnum:].-')
+          # Fetch version from npm (more reliable than deprecated API endpoint)
+          VERSION=$(npm view opencode-ai version 2>/dev/null)
       
-          # Validate: ensure it looks like a version string (not HTML/CSS)
-          if [[ ! "$VERSION" =~ ^[a-zA-Z0-9._-]+$ ]] || [[ -z "$VERSION" ]]; then
+          # Validate: ensure it looks like a version string
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ -z "$VERSION" ]]; then
             echo "VERSION environment variable is invalid or empty."
             exit 1
           fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Cache OpenCode CLI
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary

Fixes issue #62 - "Premium models not working"

### Problem

The workflow was trying to fetch the OpenCode version from `https://opencode.ai/api/version`, but that endpoint no longer exists (returns 404). This caused the workflow to fail at the version check step:

```bash
VERSION=$(curl -s https://opencode.ai/api/version 2>/dev/null | head -n 1 | tr -cd '[:alnum:].-')
# This returns 404, causing the validation to fail
```

### Solution

Replace the deprecated API endpoint with npm to get the version:

```bash
VERSION=$(npm view opencode-ai version 2>/dev/null)
```

This is more reliable because:
1. npm is already installed in the workflow (via `oven-sh/setup-bun`)
2. The npm registry is more stable than the custom API endpoint
3. Returns the version in a cleaner format (e.g., `1.2.5`)

### Changes

- `.github/workflows/cloudwaddie-agent.yml`: Updated version fetch step to use npm instead of the deprecated API endpoint

### Testing

The version fetch now returns `1.2.5` (latest) instead of failing with 404.