### PR TITLE
Upgrade free workflow model from big-pickle to minimax-m2.5-free

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,7 +36,7 @@ Go to your repository's **Settings → Secrets and variables → Actions** and a
 
 **Purpose**: Use premium OpenCode models (Claude, GPT, etc.) instead of free models.
 
-**Without this secret**: The bot uses free OpenCode models like `opencode/big-pickle` (works fine for basic tasks).
+**Without this secret**: The bot uses free OpenCode models like `opencode/minimax-m2.5-free` (works fine for basic tasks).
 
 **With this secret**: The bot can use premium models for better responses.
 
@@ -296,14 +296,14 @@ The workflow has no timeout by default (uses GitHub's 6-hour limit). If you see 
 
 ### Bot gives poor responses
 
-If using free models (`opencode/big-pickle`):
+If using free models (`opencode/minimax-m2.5-free`):
 - Responses may be less accurate than premium models
 - Consider adding `OPENCODE_AUTH_JSON` secret with premium API keys
 
 ## Models Used
 
 ### Default (Free)
-- `opencode/big-pickle` - Free OpenCode model
+- `opencode/minimax-m2.5-free` - Free OpenCode model
 
 ### With Authentication (Premium)
 The bot uses different models based on available credentials:
@@ -333,13 +333,13 @@ The bot uses different models based on available credentials:
 
 Edit the workflow file and modify:
 ```yaml
-# Set default model to opencode/big-pickle
+# Set default model to opencode/minimax-m2.5-free
 CONFIG=~/.config/opencode/opencode.json
 if [ -f "$CONFIG" ]; then
-  jq '(.model = "opencode/big-pickle")' "$CONFIG" > /tmp/oc.json && mv /tmp/oc.json "$CONFIG"
+  jq '(.model = "opencode/minimax-m2.5-free")' "$CONFIG" > /tmp/oc.json && mv /tmp/oc.json "$CONFIG"
 ```
 
-Change `opencode/big-pickle` to your preferred model.
+Change `opencode/minimax-m2.5-free` to your preferred model.
 
 ### Adjust Bot Behavior
 

--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -191,7 +191,7 @@ jobs:
 
           if [[ -z "$OPENCODE_AUTH_JSON" ]]; then
             echo "No auth provided - using free OpenCode models"
-            jq '.model = "opencode/big-pickle"' "$OPENCODE_JSON" > /tmp/oc.json && mv /tmp/oc.json "$OPENCODE_JSON"
+            jq '.model = "opencode/minimax-m2.5-free"' "$OPENCODE_JSON" > /tmp/oc.json && mv /tmp/oc.json "$OPENCODE_JSON"
           fi
 
           # Configure oh-my-opencode prompt_append with ultrawork mode

--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ Copy the workflow files from the [`.github/workflows/`](.github/workflows/) fold
 
 ## Notes
 - The workflow only runs on mentions by a **contributor** (OWNER/MEMBER/COLLABORATOR/CONTRIBUTOR)
-- Uses **free OpenCode models** by default (opencode/big-pickle)
+- Uses **free OpenCode models** by default (opencode/minimax-m2.5-free)
 - Authentication is optional - works with free models out of the box
 - The bot **always posts at least one comment** explaining what it did or found


### PR DESCRIPTION
## Summary
- Upgrade the default free model from `opencode/big-pickle` to `opencode/minimax-m2.5-free`
- MiniMax M2.5 Free is the most capable model from the available free models list (Kimi K2.5 Free, Big Pickle, MiniMax M2.5 Free, GPT 5 Nano)
- According to benchmarks, MiniMax M2.5 is described as an "Opus 4.6 level model"
- This change only applies to the free workflow when there is no `OPENCODE_AUTH_JSON` or configured models
- Updated documentation to reflect the new default model