### PR TITLE
fix: prevent workflow cancellation (error 143)

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   agent:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
     # @cloudwaddie-agent mention only (contributors, exclude self)
     if: >-
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
## Summary

- Add `concurrency` group to the workflow to prevent automatic cancellation of in-progress runs
- Error 143 = SIGTERM indicates the workflow was being cancelled mid-execution
- The fix uses `cancel-in-progress: false` to allow long-running agent tasks to complete

## Root Cause

The workflow was being cancelled by GitHub Actions (not crashing). The logs show:
```
The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
Process completed with exit code 143.
```

Without a `concurrency` group, GitHub Actions automatically cancels in-progress runs when a new run is triggered on the same branch. This was causing the agent's long-running tasks to be terminated prematurely.

## Changes

```yaml
jobs:
  agent:
    runs-on: ubuntu-latest
    concurrency:
      group: ${{ github.workflow }}-${{ github.ref }}
      cancel-in-progress: false
```

This ensures:
1. Only one run per branch at a time
2. In-progress runs are never automatically cancelled
3. Long-running agent tasks can complete without interruption