### PR TITLE
fix: always run bun install to ensure node_modules are current

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -126,11 +126,12 @@ jobs:
       - name: Build oh-my-opencode
         working-directory: oh-my-opencode
         run: |
+          # Always install dependencies (needed for src/index.ts runtime resolution)
+          bun install
           # Skip build if dist already cached and valid
           if [ -d "dist" ] && [ "$(ls -A dist)" ]; then
             echo "Using cached dist folder"
           else
-            bun install
             bun run build
           fi
 


### PR DESCRIPTION
## Summary
- Always run `bun install` before checking if the dist cache is valid, instead of skipping it when dist is cached
- The plugin is loaded from `src/index.ts` at runtime, which requires all `node_modules` to be present including recently-added dependencies like `diff`
- Previously, if the dist cache hit, `bun install` was skipped entirely, causing runtime failures when new packages were added to oh-my-opencode's dev branch

## Root Cause
The `oh-my-opencode` dev branch added a `diff-utils.ts` file that imports from the `diff` npm package. When the dist cache was restored from a previous run, `bun install` was skipped. The plugin is configured to load from `src/index.ts` (not the bundled dist), so Bun resolves imports from `node_modules` at runtime — failing with `Cannot find package 'diff'`.

## Test plan
- [ ] Trigger cloudwaddie-agent on an issue in a repo using this workflow
- [ ] Verify `bun install` runs even when dist cache is hit
- [ ] Verify session creation succeeds (no 503 error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)