### PR TITLE
feat: auto-sync workflow from actions-agent on every agent run

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -46,6 +46,56 @@ jobs:
           token: ${{ secrets.GH_PAT }}
           fetch-depth: 0
 
+      # Auto-sync this workflow from actions-agent source
+      - name: Sync workflow from actions-agent
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          # Skip sync if this IS the actions-agent repo
+          if [[ "${{ github.repository }}" == "CloudWaddie/actions-agent" ]]; then
+            echo "Source repo — skipping sync"
+            exit 0
+          fi
+
+          curl -sSfL \
+            "https://raw.githubusercontent.com/CloudWaddie/actions-agent/main/.github/workflows/cloudwaddie-agent.yml" \
+            -o /tmp/cloudwaddie-agent.yml
+
+          if diff -q .github/workflows/cloudwaddie-agent.yml /tmp/cloudwaddie-agent.yml > /dev/null 2>&1; then
+            echo "Workflow is up to date"
+            exit 0
+          fi
+
+          echo "Workflow is outdated — creating sync PR"
+          BRANCH="auto/sync-agent-workflow"
+
+          git config user.name "cloudwaddie-agent"
+          git config user.email "cloudwaddie-agent@users.noreply.github.com"
+
+          # Close existing sync PR if any
+          existing_pr=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$existing_pr" ]; then
+            gh pr close "$existing_pr" --delete-branch || true
+          fi
+
+          git checkout -B "$BRANCH"
+          cp /tmp/cloudwaddie-agent.yml .github/workflows/cloudwaddie-agent.yml
+          git add .github/workflows/cloudwaddie-agent.yml
+          git commit -m "chore: sync cloudwaddie-agent.yml from actions-agent"
+          git push -f origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: sync cloudwaddie-agent.yml from actions-agent" \
+            --body "$(cat <<'PREOF'
+          Automated sync of \`cloudwaddie-agent.yml\` from [CloudWaddie/actions-agent](https://github.com/CloudWaddie/actions-agent).
+
+          This PR was created automatically because the local copy differs from the source.
+          PREOF
+          )"
+
+          # Switch back to the original branch so the rest of the job runs normally
+          git checkout -
+
       # Git config - commits as cloudwaddie-agent
       - name: Configure Git as cloudwaddie-agent
         run: |


### PR DESCRIPTION
## Summary
- Adds a sync step to the `agent` job that runs before every agent invocation
- Fetches the latest `cloudwaddie-agent.yml` from `CloudWaddie/actions-agent` main branch
- If the local copy is outdated, automatically creates a PR (`auto/sync-agent-workflow`) to update it
- Skips sync on the source repo (`CloudWaddie/actions-agent`) itself

## Test plan
- [ ] Deploy to LMArenaBridge, trigger agent manually, confirm sync PR is created when files differ
- [ ] Confirm no sync PR when files are identical
- [ ] Confirm sync step is skipped on actions-agent repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)