### PR TITLE
fix: resolve placeholder substitution for URLs and paths

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -645,13 +645,15 @@ jobs:
           PROMPT_EOF
           )
 
-          PROMPT="${PROMPT//AUTHOR_PLACEHOLDER/$COMMENT_AUTHOR}"
-          PROMPT="${PROMPT//REPO_PLACEHOLDER/$REPO_NAME}"
-          PROMPT="${PROMPT//TYPE_PLACEHOLDER/$CONTEXT_TYPE}"
-          PROMPT="${PROMPT//NUMBER_PLACEHOLDER/$CONTEXT_NUMBER}"
-          PROMPT="${PROMPT//TITLE_PLACEHOLDER/$CONTEXT_TITLE}"
-          PROMPT="${PROMPT//BRANCH_PLACEHOLDER/$DEFAULT_BRANCH}"
-          PROMPT="${PROMPT//COMMENT_PLACEHOLDER/$USER_COMMENT}"
+          # Use sed with # delimiter to handle values containing /
+          PROMPT=$(echo "$PROMPT" | sed "s#AUTHOR_PLACEHOLDER#$COMMENT_AUTHOR#g")
+          PROMPT=$(echo "$PROMPT" | sed "s#REPO_PLACEHOLDER#$REPO_NAME#g")
+          PROMPT=$(echo "$PROMPT" | sed "s#TYPE_PLACEHOLDER#$CONTEXT_TYPE#g")
+          PROMPT=$(echo "$PROMPT" | sed "s#NUMBER_PLACEHOLDER#$CONTEXT_NUMBER#g")
+          PROMPT=$(echo "$PROMPT" | sed "s#TITLE_PLACEHOLDER#$CONTEXT_TITLE#g")
+          PROMPT=$(echo "$PROMPT" | sed "s#BRANCH_PLACEHOLDER#$DEFAULT_BRANCH#g")
+          # Use Python for USER_COMMENT to handle all special characters safely
+          PROMPT=$(python3 -c "import sys; print(sys.stdin.read().replace('COMMENT_PLACEHOLDER', '''$USER_COMMENT'''))" <<< "$PROMPT")
           
           stdbuf -oL -eL bun run oh-my-opencode/dist/cli/index.js run "$PROMPT"
 


### PR DESCRIPTION
## Summary

- Fix bash string substitution that fails when user comments contain `/` characters (URLs, paths, code)
- Use `sed` with `#` delimiter for safe replacement of AUTHOR, REPO, TYPE, NUMBER, TITLE, BRANCH placeholders
- Use Python for COMMENT_PLACEHOLDER to safely handle any special characters

This resolves issue #79 where placeholders weren't being substituted correctly when user comments contained URLs or file paths.