### PR TITLE
fix: add oh-my-opencode ignore instructions to workflow prompt

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -503,6 +503,13 @@ jobs:
           export PATH="$HOME/.opencode/bin:$PATH"
 
           PROMPT=$(cat <<'PROMPT_EOF'
+          [CRITICAL] IGNORE DIRECTORY - DO NOT READ
+          =========================================
+          The `oh-my-opencode/` directory contains the agent's own tooling (from code-yeongyu/oh-my-opencode).
+          IT IS NOT PART OF ANY TASK. COMPLETELY IGNORE IT. DO NOT READ FILES IN IT. DO NOT ANALYZE IT.
+          FOCUS ONLY ON THE ACTUAL PROJECT BEING WORKED ON.
+          =========================================
+
           [analyze-mode]
           ANALYSIS MODE. Gather context before diving deep:
 


### PR DESCRIPTION
## Summary

- Added explicit **IGNORE DIRECTORY** instructions at the very beginning of the agent prompt to ensure the agent completely ignores the `oh-my-opencode/` directory
- This directory contains the agent's own tooling and is NOT part of any task
- Prevents the agent from wasting time reading through the oh-my-opencode codebase