### PR TITLE
fix: co-author commits to repo owner and prevent duplicate sync PRs

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -71,23 +71,26 @@ jobs:
           BRANCH="auto/sync-agent-workflow"
           REPO="${{ github.repository }}"
 
+          existing_pr=$(gh pr list --repo "$REPO" --head "cloudwaddie-agent:$BRANCH" --json number,state --jq '.[0]' 2>/dev/null || true)
+          if [ -n "$existing_pr" ]; then
+            PR_STATE=$(echo "$existing_pr" | jq -r '.state')
+            if [ "$PR_STATE" == "OPEN" ]; then
+              echo "Sync PR already exists and is open — skipping"
+              exit 0
+            fi
+            gh pr close "$existing_pr" --repo "$REPO" --delete-branch || true
+          fi
+
           git config user.name "cloudwaddie-agent"
           git config user.email "cloudwaddie-agent@users.noreply.github.com"
 
           # Fork the repo (idempotent — no-op if already forked)
           gh repo fork "$REPO" --remote=false 2>/dev/null || true
-          FORK="cloudwaddie-agent/$(basename "$REPO")"
-
-          # Close existing sync PR if any
-          existing_pr=$(gh pr list --repo "$REPO" --head "cloudwaddie-agent:$BRANCH" --json number --jq '.[0].number' 2>/dev/null || true)
-          if [ -n "$existing_pr" ]; then
-            gh pr close "$existing_pr" --repo "$REPO" --delete-branch || true
-          fi
 
           git checkout -B "$BRANCH"
           cp /tmp/cloudwaddie-agent.yml .github/workflows/cloudwaddie-agent.yml
           git add .github/workflows/cloudwaddie-agent.yml
-          git commit -m "chore: sync cloudwaddie-agent.yml from actions-agent"
+          git commit -m "chore: sync cloudwaddie-agent.yml from actions-agent" -m "Co-authored-by: CloudWaddie <CloudWaddie@users.noreply.github.com>"
           git push -f "https://github.com/$FORK.git" "$BRANCH"
 
           gh pr create \
@@ -386,6 +389,7 @@ jobs:
           ### Git Config
           - user.name: cloudwaddie-agent
           - user.email: cloudwaddie-agent@users.noreply.github.com
+          - ALL commits MUST be co-authored to the repo owner using: `git commit -m "message" -m "Co-authored-by: CloudWaddie <CloudWaddie@users.noreply.github.com>"`
           PROMPT_EOF
           )
           jq --arg append "$PROMPT_APPEND" '.agents.Sisyphus.prompt_append = $append' "$OMO_JSON" > /tmp/omo.json && mv /tmp/omo.json "$OMO_JSON"
@@ -550,12 +554,24 @@ jobs:
 
           ### [CODE RED] MANDATORY OUTPUT REQUIREMENT
 
-          **YOU MUST POST AT LEAST ONE COMMENT. SILENT COMPLETION = FAILURE.**
+          **YOU MUST POST AT least one comment. SILENT COMPLETION = FAILURE.**
 
           - Every task MUST result in at least one comment via `gh issue comment` or `gh pr comment`
           - Explain what you found, what you did, or why you couldn't complete the task
           - NEVER finish without posting a comment - the user cannot see console output
           - If you have nothing to report, comment to acknowledge you saw the request and explain why no action was needed
+
+          ---
+
+          ### [CODE RED] MANDATORY CO-AUTHORING
+
+          **ALL COMMITS MUST be co-authored to the repo owner (CloudWaddie).**
+
+          When making commits, ALWAYS use this format:
+          ```bash
+          git commit -m "your message" -m "Co-authored-by: CloudWaddie <CloudWaddie@users.noreply.github.com>"
+          ```
+          This applies to ALL commits, including PRs and every single commit in feature branches.
 
           ---
 


### PR DESCRIPTION
## Summary
- Add co-authored-by to sync workflow commit
- Add mandatory co-authoring instruction to agent prompt
- Skip sync PR creation if one already exists (instead of closing and recreating)

## Changes

### 1. Co-authoring for all commits
- Added `Co-authored-by: CloudWaddie <CloudWaddie@users.noreply.github.com>` to the sync workflow commit
- Added prominent instructions in the agent prompt requiring ALL commits to be co-authored to the repo owner

### 2. Prevent duplicate sync PRs
- Previously, the auto-sync step would close any existing sync PR and create a new one
- Now it checks if an open sync PR already exists and skips creation if one is already open
- Only creates a new PR if no open PR exists (or if the existing one is closed)