### PR TITLE
fix: notify on cancelled workflow runs

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -685,7 +685,7 @@ jobs:
           exit $EXIT_CODE
 
       - name: Notify on agent interruption
-        if: failure() && steps.agent-run.outcome == 'failure'
+        if: steps.agent-run.outcome != 'success'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -696,7 +696,7 @@ jobs:
             exit 0
           fi
           BODY=$(cat <<'NOTIFY_EOF'
-          :warning: **Agent interrupted** - the GitHub Actions runner was shut down before I could finish (exit code 143/SIGTERM).
+          :warning: **Agent interrupted** - the GitHub Actions runner was shut down or cancelled before I could finish.
 
           This can happen when:
           - The runner VM was preempted or recycled by GitHub


### PR DESCRIPTION
## Summary

Fixes the notification step to trigger when the agent run is **cancelled** (not just failed).

## Problem

In run 22608524051 on LMArenaBridge, the agent was actively working when the GitHub runner received a shutdown signal. The agent step was **cancelled** (not failed), but the notification step had this condition:

```yaml
if: failure() && steps.agent-run.outcome == 'failure'
```

This evaluates to `false` when the outcome is `cancelled`, so users never got notified.

## Changes

1. **Change condition**: `failure() && steps.agent-run.outcome == 'failure'` → `steps.agent-run.outcome != 'success'`
   - Now triggers on: failure, cancelled, or skipped

2. **Update message**: Remove specific reference to "exit code 143/SIGTERM" since cancelled runs may have different exit codes

## Related

This issue manifested in https://github.com/CloudWaddie/LMArenaBridge/actions/runs/22608524051 where the agent was interrupted mid-work by a runner shutdown.