### PR TITLE
fix: set FORK variable before git push in sync step

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -87,6 +87,8 @@ jobs:
           # Fork the repo (idempotent — no-op if already forked)
           gh repo fork "$REPO" --remote=false 2>/dev/null || true
 
+          # Get the authenticated user's login (the one who will have the fork)
+          FORK=$(gh api user --jq '.login')
           git checkout -B "$BRANCH"
           cp /tmp/cloudwaddie-agent.yml .github/workflows/cloudwaddie-agent.yml
           git add .github/workflows/cloudwaddie-agent.yml


### PR DESCRIPTION
## Summary
- Fix the auto-update sync step failing because `$FORK` variable was never set before using it in the git push command.

## Root Cause
The workflow tries to push to `https://github.com/$FORK.git` but `$FORK` was never defined. The `gh repo fork` command forks the repo but doesn't return the fork name - we need to query the authenticated user's login separately.

## Fix
Added `FORK=$(gh api user --jq '.login')` after the `gh repo fork` command to get the authenticated user's login (the cloudwaddie-agent bot account).

This was causing the sync workflow in LMArenaBridge to fail with:
```
remote: Not Found
fatal: repository 'https://github.com/.git/' not found
```