### PR TITLE
fix: configure git user identity before sync commit

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -77,6 +77,10 @@ jobs:
           # Fork the repo (idempotent — no-op if already forked)
           gh repo fork "$REPO_FULL" --remote=false 2>/dev/null || true
           
+          # Configure git user identity (required for commits in sync step)
+          git config user.name "cloudwaddie-agent"
+          git config user.email "cloudwaddie-agent@users.noreply.github.com"
+
           # Get the authenticated user's login (the one who will have the fork)
           FORK=$(gh api user --jq '.login')
           git checkout -B "$BRANCH"


### PR DESCRIPTION
## Summary
- Fixes the sync workflow failing with "empty ident name" error in LMArenaBridge and other repos that use this workflow

## Problem
The "Sync workflow from actions-agent" step was attempting `git commit` before git user identity was configured, causing:
```
Author identity unknown
...
fatal: empty ident name (for <runner@...>) not allowed
```

## Solution
Moves the git config (user.name and user.email) into the sync step, before the commit is attempted.

This fix is in the source repo (actions-agent). Once merged, the sync mechanism will propagate the fix to LMArenaBridge, yuppbridge, and any other repos using this workflow.