### PR TITLE
feat: add custom OpenAI-compatible provider support

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -196,6 +196,9 @@ jobs:
       - name: Setup OpenCode with oh-my-opencode
         env:
           OPENCODE_AUTH_JSON: ${{ secrets.OPENCODE_AUTH_JSON }}
+          CUSTOM_PROVIDER_BASE_URL: ${{ secrets.CUSTOM_PROVIDER_BASE_URL }}
+          CUSTOM_PROVIDER_API_KEY: ${{ secrets.CUSTOM_PROVIDER_API_KEY }}
+          CUSTOM_PROVIDER_MODEL: ${{ secrets.CUSTOM_PROVIDER_MODEL }}
         run: |
           export PATH="$HOME/.opencode/bin:$PATH"
 
@@ -253,6 +256,45 @@ jobs:
           if [[ -z "$OPENCODE_AUTH_JSON" ]]; then
             echo "No auth provided - using free OpenCode models"
             jq '.model = "opencode/big-pickle"' "$OPENCODE_JSON" > /tmp/oc.json && mv /tmp/oc.json "$OPENCODE_JSON"
+          fi
+
+          # Configure custom provider if environment variables are set
+          if [[ -n "$CUSTOM_PROVIDER_BASE_URL" ]]; then
+            echo "Configuring custom provider: $CUSTOM_PROVIDER_BASE_URL"
+            
+            CUSTOM_MODEL="${CUSTOM_PROVIDER_MODEL:-free-max}"
+            
+            # 1. Register provider in opencode.json (REQUIRED)
+            jq --arg baseURL "$CUSTOM_PROVIDER_BASE_URL" \
+               --arg model "$CUSTOM_MODEL" \
+               '.provider."custom-provider" = {
+                 "npm": "@ai-sdk/openai-compatible",
+                 "name": "Custom Provider",
+                 "options": {
+                   "baseURL": $baseURL
+                 },
+                 "models": {
+                   ($model): {}
+                 }
+               }' "$OPENCODE_JSON" > /tmp/oc.json && mv /tmp/oc.json "$OPENCODE_JSON"
+            
+            # 2. Add API key to auth.json
+            mkdir -p ~/.local/share/opencode
+            if [[ ! -f ~/.local/share/opencode/auth.json ]]; then
+              echo '{}' > ~/.local/share/opencode/auth.json
+            fi
+            
+            jq --arg apiKey "${CUSTOM_PROVIDER_API_KEY:-}" \
+               '."custom-provider" = {
+                 "type": "api",
+                 "key": $apiKey
+               }' ~/.local/share/opencode/auth.json > /tmp/auth.json && mv /tmp/auth.json ~/.local/share/opencode/auth.json
+            chmod 600 ~/.local/share/opencode/auth.json
+            
+            # 3. Set as default model
+            jq --arg model "custom-provider/$CUSTOM_MODEL" '.model = $model' "$OPENCODE_JSON" > /tmp/oc2.json && mv /tmp/oc2.json "$OPENCODE_JSON"
+            
+            echo "Custom provider configured with model: custom-provider/$CUSTOM_MODEL"
           fi
 
           # Configure oh-my-opencode prompt_append with ultrawork mode


### PR DESCRIPTION
## Summary

Adds support for custom OpenAI-compatible API providers (like CloudWaddie's `ai.cloudwaddie.com/v1`) via environment variables.

## Changes

- **Add environment variables**: `CUSTOM_PROVIDER_BASE_URL`, `CUSTOM_PROVIDER_API_KEY`, `CUSTOM_PROVIDER_MODEL`
- **Register provider in `opencode.json`**: Uses `@ai-sdk/openai-compatible` npm package with proper configuration
- **Configure API key in `auth.json`**: Correct format with `type: "api"` and `key` fields
- **Set as default model**: Automatically uses custom provider when configured

## Technical Details

The implementation follows OpenCode's official custom provider pattern:

1. **Provider Registration** (`opencode.json`):
   ```json
   {
     "provider": {
       "custom-provider": {
         "npm": "@ai-sdk/openai-compatible",
         "name": "Custom Provider",
         "options": {
           "baseURL": "https://ai.cloudwaddie.com/v1"
         },
         "models": {
           "free-max": {}
         }
       }
     }
   }
   ```

2. **API Key Storage** (`auth.json`):
   ```json
   {
     "custom-provider": {
       "type": "api",
       "key": "your-api-key"
     }
   }
   ```

3. **Default Model** (`opencode.json`):
   ```json
   {
     "model": "custom-provider/free-max"
   }
   ```

## Usage

Set these GitHub repository secrets:

- `CUSTOM_PROVIDER_BASE_URL` = `https://ai.cloudwaddie.com/v1`
- `CUSTOM_PROVIDER_API_KEY` = your API key
- `CUSTOM_PROVIDER_MODEL` = `free-max` (optional, defaults to "free-max")

When these secrets are set, the workflow will automatically configure OpenCode to use the custom provider instead of free models.

## Testing

To test:
1. Add the secrets to your repository
2. Trigger the workflow by mentioning `@cloudwaddie-agent` in an issue
3. Check workflow logs for "Configuring custom provider: https://ai.cloudwaddie.com/v1"
4. Verify the agent uses your custom API endpoint

## Notes

- Falls back to free OpenCode models if custom provider secrets are not set
- Compatible with existing `OPENCODE_AUTH_JSON` configuration
- Follows OpenCode's official custom provider documentation